### PR TITLE
Remove CJK font fallbacks from text and monospace font stacks

### DIFF
--- a/theme.css
+++ b/theme.css
@@ -44,8 +44,8 @@ body {
   --list-indent: 2em;
   --list-spacing: 0.1em;
   /* 字体 */
-  --font-text-theme: 'LXGW Bright', 'JetBrains Mono', 'LXGW WenKai Screen', '霞鹜文楷 屏幕阅读版';
-  --font-monospace: 'JetBrains Mono', 'LXGW WenKai Screen', '霞鹜文楷 屏幕阅读版';
+  --font-text-theme: 'LXGW Bright', 'JetBrains Mono';
+  --font-monospace: 'JetBrains Mono';
   --font-quote: 'Source Serif 4', 'STKaiti';
   --font-accent: 'Source Serif 4', 'Source Han Serif SC';
   /* 链接 */


### PR DESCRIPTION
## Summary
- Simplify `--font-text-theme` and `--font-monospace` CSS variables by removing `'LXGW WenKai Screen'` and `'霞鹜文楷 屏幕阅读版'` fallback fonts
- Keeps `'LXGW Bright'` and `'JetBrains Mono'` as the primary fonts

## Test plan
- [ ] Verify text renders correctly in Reading mode
- [ ] Verify text renders correctly in Live Preview mode
- [ ] Verify monospace/code blocks render correctly
- [ ] Check CJK text still displays properly with system fallbacks

🤖 Generated with [Claude Code](https://claude.com/claude-code)